### PR TITLE
Attempt implementing NaN-checks for floating-point variables.

### DIFF
--- a/analysis/naninit.d
+++ b/analysis/naninit.d
@@ -1,0 +1,63 @@
+//          Copyright Brian Schott (Sir Alaran) 2014.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module analysis.naninit;
+
+import std.stdio;
+
+import std.d.ast;
+import std.d.lexer;
+import analysis.base;
+import analysis.helpers;
+
+/**
+ * Checks for floating-point variables default-initialized to NaN.
+ */
+class NanInitCheck : BaseAnalyzer
+{
+	alias visit = BaseAnalyzer.visit;
+
+	this(string fileName)
+	{
+		super(fileName);
+	}
+
+	override void visit(const VariableDeclaration vd)
+	{
+		switch (vd.type.type2.builtinType)
+		{
+			case tok!"double":
+			case tok!"idouble":
+			case tok!"float":
+			case tok!"ifloat":
+			case tok!"real":
+			case tok!"ireal":
+			{
+				foreach (dec; vd.declarators)
+				{
+					if (dec.initializer is null)
+						addErrorMessage(dec.name.line, dec.name.column,
+							"Variable is default-initialized to NaN");
+				}
+			}
+
+			default:
+		}
+
+		vd.accept(this);
+	}
+}
+
+unittest
+{
+	assertAnalyzerWarnings(q{
+		void testNan()
+		{
+			float x;
+			float[3] arr;
+		}
+	}c, analysis.run.AnalyzerCheck.nan_init_check);
+	stderr.writeln("Unittest for NanInitCheck passed.");
+}

--- a/analysis/run.d
+++ b/analysis/run.d
@@ -36,6 +36,7 @@ enum AnalyzerCheck : int
 	if_else_same_check = 0x100,
 	constructor_check = 0x200,
 	unused_variable_check = 0x400,
+	nan_init_check = 0x800,
 	all = 0x7FF
 }
 
@@ -104,6 +105,7 @@ string[] analyze(string fileName, ubyte[] code, AnalyzerCheck analyzers, bool st
 	if (analyzers & AnalyzerCheck.if_else_same_check) checks ~= new IfElseSameCheck(fileName);
 	if (analyzers & AnalyzerCheck.constructor_check) checks ~= new ConstructorCheck(fileName);
 	if (analyzers & AnalyzerCheck.unused_variable_check) checks ~= new UnusedVariableCheck(fileName);
+	if (analyzers & AnalyzerCheck.nan_init_check) checks ~= new NanInitCheck(fileName);
 
 	foreach (check; checks)
 	{


### PR DESCRIPTION
There's no need to merge this, I'm just testing things out and trying to figure out how much more complicated this would be to implement in a 3rd party tool rather than in the compiler as in [this pull request](https://github.com/D-Programming-Language/dmd/pull/3573).