### PR TITLE
git submodules don't work with dub

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,8 +5,10 @@
 	"authors": ["Brian Schott"],
 	"license" : "Boost Software License - Version 1.0",
 	"targetType": "executable",
+	"preBuildCommands": ["git log -1 --format='%H' > githash.txt"],
+	"stringImportPaths": ["."],
 	"dependencies": {
-		"libdparse": { "path": "libdparse/" },
-		"inifiled": { "path": "inifiled/" }
-	}
+		"libdparse": "~>0.2.0",
+		"inifiled": ">=0.0.3",
+	},
 }


### PR DESCRIPTION
Submodules also aren't included in github's src packages.
I'd recommend making libdparse a separate dub package, which is also cleaner when only the lexer/parser libraries are needed in another project.