### PR TITLE
add --enforce flag to error on warnings

### DIFF
--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -98,10 +98,11 @@ void writeJSON(string key, string fileName, size_t line, size_t column, string m
 	write("    }");
 }
 
-bool syntaxCheck(string[] fileNames, ref StringCache stringCache, ref ModuleCache moduleCache)
+bool syntaxCheck(string[] fileNames, ref StringCache stringCache, ref ModuleCache moduleCache,
+					bool enforce = false)
 {
 	StaticAnalysisConfig config = defaultStaticAnalysisConfig();
-	return analyze(fileNames, config, stringCache, moduleCache, false);
+	return analyze(fileNames, config, stringCache, moduleCache, false, enforce);
 }
 
 void generateReport(string[] fileNames, const StaticAnalysisConfig config,
@@ -147,7 +148,8 @@ void generateReport(string[] fileNames, const StaticAnalysisConfig config,
  * Returns: true if there were errors or if there were warnings and `staticAnalyze` was true.
  */
 bool analyze(string[] fileNames, const StaticAnalysisConfig config,
-		ref StringCache cache, ref ModuleCache moduleCache, bool staticAnalyze = true)
+		ref StringCache cache, ref ModuleCache moduleCache, bool staticAnalyze = true,
+		bool enforce = false)
 {
 	bool hasErrors = false;
 	foreach (fileName; fileNames)
@@ -171,6 +173,8 @@ bool analyze(string[] fileNames, const StaticAnalysisConfig config,
 		foreach (result; results[])
 			writefln("%s(%d:%d)[warn]: %s", result.fileName, result.line,
 					result.column, result.message);
+		if (enforce)
+			hasErrors = true;
 	}
 	return hasErrors;
 }

--- a/src/main.d
+++ b/src/main.d
@@ -63,6 +63,7 @@ else
 	string[] importPaths;
 	bool printVersion;
 	bool explore;
+	bool enforce;
 
 	try
 	{
@@ -88,7 +89,8 @@ else
 				"I", &importPaths,
 				"version", &printVersion,
 				"muffinButton", &muffin,
-				"explore", &explore);
+				"explore", &explore,
+				"enforce", &enforce);
 		//dfmt on
 	}
 	catch (ConvException e)
@@ -219,11 +221,11 @@ else
 		if (report)
 			generateReport(expandArgs(args), config, cache, moduleCache);
 		else
-			return analyze(expandArgs(args), config, cache, moduleCache, true) ? 1 : 0;
+			return analyze(expandArgs(args), config, cache, moduleCache, true, enforce) ? 1 : 0;
 	}
 	else if (syntaxCheck)
 	{
-		return .syntaxCheck(usingStdin ? ["stdin"] : expandArgs(args), cache, moduleCache) ? 1 : 0;
+		return .syntaxCheck(usingStdin ? ["stdin"] : expandArgs(args), cache, moduleCache, enforce) ? 1 : 0;
 	}
 	else
 	{
@@ -404,7 +406,10 @@ Options:
         $HOME/.config/dscanner/dscanner.ini
 
     --defaultConfig
-        Generates a default configuration file for the static analysis checks`,
+        Generates a default configuration file for the static analysis checks
+
+    --enforce
+        Exits with an error code if warnings are found during static analysis`,
 			programName);
 }
 


### PR DESCRIPTION
I imagine this to be useful if a project uses DScanner for linting and wants to `enforce` their style guide.