### PR TITLE
fix small typo in dscanner.ini

### DIFF
--- a/src/analysis/config.d
+++ b/src/analysis/config.d
@@ -15,7 +15,7 @@ StaticAnalysisConfig defaultStaticAnalysisConfig()
 	return config;
 }
 
-@INI("Configurue which static analysis checks are enabled")
+@INI("Configure which static analysis checks are enabled")
 struct StaticAnalysisConfig
 {
 	@INI("Check variable, class, struct, interface, union, and function names against the Phobos style guide")


### PR DESCRIPTION
btw English is not my mother tongue, but instead of "Configure which static analysis checks are enabled"  I would say "Configure which static analysis checks to enable".