### PR TITLE
Check for two or more consecutive empty lines

### DIFF
--- a/src/analysis/allman.d
+++ b/src/analysis/allman.d
@@ -1,0 +1,203 @@
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module analysis.allman;
+
+import dparse.lexer;
+import dparse.ast;
+import analysis.base : BaseAnalyzer;
+import dsymbol.scope_ : Scope;
+
+/**
+Checks for the allman style (braces should be on their own line)
+
+------------
+if (param < 0) {
+
+}
+------------
+
+should be
+
+------------
+if (param < 0)
+{
+
+}
+------------
+*/
+class AllManCheck : BaseAnalyzer
+{
+    ubyte[] code;
+
+    ///
+	this(string fileName, ubyte[] code, bool skipTests = false)
+	{
+		super(fileName, null, skipTests);
+		this.code = code;
+    }
+
+	override void visit(const WhileStatement st)
+	{
+        if (st.declarationOrStatement !is null)
+            checkForBrace(st.declarationOrStatement, st.expression.line, st.expression.column);
+    }
+
+    override void visit(const ForeachStatement st)
+    {
+        checkForBrace(st.declarationOrStatement, st.low.line, st.low.column);
+    }
+
+    override void visit(const ForStatement st)
+    {
+        checkForBrace(st.declarationOrStatement, st.test.line, st.test.column);
+    }
+
+    override void visit(const DoStatement st)
+    {
+        // the DoStatement only knows about the line and column of the expression
+        checkForBrace(st.statementNoCaseNoDefault, 0, 0);
+        st.statementNoCaseNoDefault.accept(this);
+    }
+
+	override void visit(const IfStatement st)
+	{
+        checkForBrace(st.thenStatement, st.expression.line, st.expression.column);
+        if (st.elseStatement !is null)
+            checkForBrace(st.elseStatement, st.expression.line, st.expression.column);
+    }
+
+	alias visit = ASTVisitor.visit;
+
+private:
+
+    void checkForBrace(const DeclarationOrStatement declOrSt, size_t line, size_t column)
+    {
+        if(auto stst = declOrSt.statement)
+        {
+            checkForBrace(stst.statementNoCaseNoDefault, line, column);
+        }
+        declOrSt.accept(this);
+    }
+
+    void checkForBrace(const StatementNoCaseNoDefault stNo, size_t line, size_t column)
+    {
+        if(stNo !is null)
+        {
+            findBraceOrNewLine(stNo.startLocation, stNo.endLocation, line, column);
+        }
+    }
+
+    /**
+    Counts all matches of an symbol and the number of iterated characters
+    */
+    auto findLast(size_t start, char symbol)
+    {
+        import std.utf: byCodeUnit;
+        import std.typecons: tuple;
+        auto text_before = (cast(char[]) code[0..start]).byCodeUnit;
+        size_t offset = 0;
+        size_t matches = 0;
+        foreach (s; text_before)
+        {
+            if (s == symbol)
+            {
+                matches++;
+            }
+            offset++;
+        }
+        return tuple!("matches", "offset")(matches, offset);
+    }
+
+    /**
+    Checks whether a brace or newline comes first
+    */
+    void findBraceOrNewLine(size_t start, size_t end, size_t line, size_t column)
+    {
+        import std.stdio;
+		import std.algorithm : canFind;
+        import std.utf: byCodeUnit;
+        auto stRange = (cast(char[]) code[start..end]).byCodeUnit;
+        // inline statements are allowed - search for newline
+        size_t charsToBrace = 0;
+        if (canFind(stRange, '\n'))
+        {
+            foreach (s; stRange)
+            {
+                // brace first
+                if (s == '{')
+                {
+                    // DoStatement doesn't has proper line and column attched
+                    // -> calulcate ourselves
+                    if (line == 0 && column == 0)
+                    {
+                        // find line & column of brace
+                        auto t = findLast(start, '\n');
+                        line = t.matches + 1;
+                        column = (start + charsToBrace) - t.offset;
+                    }
+                    addErrorMessage(line, column, KEY, MESSAGE);
+                    break;
+                }
+                // newline - test passed
+                else if (s == '\n')
+                {
+                    break;
+                }
+            }
+        }
+    }
+
+	enum string KEY = "dscanner.style.allman";
+	enum string MESSAGE = "Brace should be on their own line";
+}
+
+unittest
+{
+	import analysis.config : StaticAnalysisConfig;
+    import analysis.helpers;
+    import std.stdio;
+
+	StaticAnalysisConfig sac;
+	sac.allman_braces_check = "enabled";
+
+	assertAnalyzerWarnings(q{
+        void testAllman()
+        {
+            while (true) { // [warn]: Brace should be on their own line
+                auto f = 1;
+            }
+
+		    do { // [warn]: Brace should be on their own line
+                auto f = 1;
+            } while (true);
+
+            // inline is OK
+            while (true) { auto f = 1; }
+
+            if (true) { // [warn]: Brace should be on their own line
+                auto f = 1;
+            }
+            if (true) { auto f = 1; }
+            foreach (r; [1]) { // [warn]: Brace should be on their own line
+            }
+            foreach (r; [1]) {  }
+            foreach_reverse (r; [1]) { // [warn]: Brace should be on their own line
+            }
+            foreach_reverse (r; [1]) {  }
+            for (int i = 0; i < 10; i++) { // [warn]: Brace should be on their own line
+            }
+            for (int i = 0; i < 10; i++) { }
+
+            // nested check
+            while (true) { // [warn]: Brace should be on their own line
+                while (true) { // [warn]: Brace should be on their own line
+                    auto f = 1;
+                }
+            }
+        }
+	}c, sac);
+
+	stderr.writeln("Unittest for Allman passed.");
+}

--- a/src/analysis/config.d
+++ b/src/analysis/config.d
@@ -150,4 +150,7 @@ struct StaticAnalysisConfig
 
 	@INI("Check for trailing whitespace")
 	string trailing_whitespace_check = Check.disabled;
+
+	@INI("Check for two or more consecutive empty lines")
+	string consecutive_empty_lines = Check.disabled;
 }

--- a/src/analysis/config.d
+++ b/src/analysis/config.d
@@ -144,4 +144,7 @@ struct StaticAnalysisConfig
 
 	@INI("Check for unclear lambda syntax")
 	string lambda_return_check = Check.disabled;
+
+	@INI("Check allman brace style")
+	string allman_braces_check = Check.disabled;
 }

--- a/src/analysis/config.d
+++ b/src/analysis/config.d
@@ -147,4 +147,7 @@ struct StaticAnalysisConfig
 
 	@INI("Check allman brace style")
 	string allman_braces_check = Check.disabled;
+
+	@INI("Check for trailing whitespace")
+	string trailing_whitespace_check = Check.disabled;
 }

--- a/src/analysis/consecutive_empty_lines.d
+++ b/src/analysis/consecutive_empty_lines.d
@@ -1,0 +1,90 @@
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module analysis.consecutive_empty_lines;
+
+import dparse.lexer;
+import dparse.ast;
+import analysis.base : BaseAnalyzer, Message;
+import dsymbol.scope_ : Scope;
+
+/**
+Checks whether a file contains two or more consecutive empty lines
+*/
+class ConsecutiveEmptyLines: BaseAnalyzer
+{
+    ubyte[] code;
+
+    ///
+	this(string fileName, ubyte[] code, bool skipTests = false)
+	{
+		super(fileName, null, skipTests);
+		this.code = code;
+    }
+
+	override void visit(const Module)
+    {
+        findConsecutive();
+    }
+
+	alias visit = ASTVisitor.visit;
+
+private:
+
+    /**
+    Searches for trailing whitespace
+    */
+    void findConsecutive()
+    {
+        import std.utf: byCodeUnit;
+        import std.ascii: isWhite;
+        size_t line = 0;
+        size_t newLineCount = 0;
+        foreach (s; (cast(char[]) code).byCodeUnit)
+        {
+            if (s == '\n')
+            {
+                if (newLineCount >= 2)
+                    addErrorMessage(line, 0, KEY, MESSAGE);
+                line++;
+                newLineCount++;
+            }
+            // ignore carriage returns for windows compatibility
+            else if (!(s == '\r' || isWhite(s)))
+            {
+                newLineCount = 0;
+            }
+        }
+    }
+
+	enum string KEY = "dscanner.style.consecutive_empty_lines";
+	enum string MESSAGE = "Consecutive empty lines detected";
+}
+
+unittest
+{
+	import analysis.config : StaticAnalysisConfig;
+    import analysis.helpers;
+    import std.stdio;
+
+	StaticAnalysisConfig sac;
+	sac.consecutive_empty_lines = "enabled";
+
+	auto msgs = getAnalyzerWarnings(q{
+        void testConsecutiveEmptyLines(){
+
+
+        }
+
+        void foo(){
+
+        }
+	}c, sac);
+    assert(msgs.length == 1);
+    Message msg = Message("test", 3, 0, "dscanner.style.consecutive_empty_lines",
+                          "Consecutive empty lines detected");
+    assert(msgs.front == msg);
+
+	stderr.writeln("Unittest for ConsecutiveEmptyLines passed.");
+}

--- a/src/analysis/helpers.d
+++ b/src/analysis/helpers.d
@@ -40,11 +40,9 @@ S after(S)(S value, S separator) if (isSomeString!S)
 }
 
 /**
- * This assert function will analyze the passed in code, get the warnings,
- * and make sure they match the warnings in the comments. Warnings are
- * marked like so: // [warn]: Failed to do somethings.
- */
-void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
+* Get analzer warnings for the given code
+*/
+MessageSet getAnalyzerWarnings(string code, const StaticAnalysisConfig config,
 		string file = __FILE__, size_t line = __LINE__)
 {
 	import analysis.run : parseModule;
@@ -58,7 +56,19 @@ void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
 	auto moduleCache = ModuleCache(new CAllocatorImpl!Mallocator);
 
 	// Run the code and get any warnings
-	MessageSet rawWarnings = analyze("test", m, config, moduleCache, tokens, cast(ubyte[]) code);
+	return analyze("test", m, config, moduleCache, tokens, cast(ubyte[]) code);
+}
+
+/**
+ * This assert function will analyze the passed in code, get the warnings,
+ * and make sure they match the warnings in the comments. Warnings are
+ * marked like so: // [warn]: Failed to do somethings.
+ */
+void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
+		string file = __FILE__, size_t line = __LINE__)
+{
+
+    MessageSet rawWarnings = getAnalyzerWarnings(code, config, file, line);
 	string[] codeLines = code.split("\n");
 
 	// Get the warnings ordered by line

--- a/src/analysis/helpers.d
+++ b/src/analysis/helpers.d
@@ -58,7 +58,7 @@ void assertAnalyzerWarnings(string code, const StaticAnalysisConfig config,
 	auto moduleCache = ModuleCache(new CAllocatorImpl!Mallocator);
 
 	// Run the code and get any warnings
-	MessageSet rawWarnings = analyze("test", m, config, moduleCache, tokens);
+	MessageSet rawWarnings = analyze("test", m, config, moduleCache, tokens, cast(ubyte[]) code);
 	string[] codeLines = code.split("\n");
 
 	// Get the warnings ordered by line

--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -61,6 +61,7 @@ import analysis.static_if_else;
 import analysis.lambda_return_check;
 import analysis.allman;
 import analysis.trailing_whitespace;
+import analysis.consecutive_empty_lines;
 
 import dsymbol.string_interning : internString;
 import dsymbol.scope_;
@@ -359,6 +360,10 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
     if (analysisConfig.trailing_whitespace_check != Check.disabled)
 		checks ~= new TrailingWhitespaceCheck(fileName, code,
         analysisConfig.trailing_whitespace_check == Check.skipTests && !ut);
+
+    if (analysisConfig.consecutive_empty_lines != Check.disabled)
+		checks ~= new ConsecutiveEmptyLines(fileName, code,
+        analysisConfig.consecutive_empty_lines == Check.skipTests && !ut);
 
 	version (none)
 		if (analysisConfig.redundant_if_check != Check.disabled)

--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -59,6 +59,7 @@ import analysis.useless_assert;
 import analysis.alias_syntax_check;
 import analysis.static_if_else;
 import analysis.lambda_return_check;
+import analysis.allman;
 
 import dsymbol.string_interning : internString;
 import dsymbol.scope_;
@@ -124,7 +125,7 @@ void generateReport(string[] fileNames, const StaticAnalysisConfig config,
 		const(Token)[] tokens;
 		const Module m = parseModule(fileName, code, &r, cache, true, tokens, &lineOfCodeCount);
 		stats.visit(m);
-		MessageSet results = analyze(fileName, m, config, moduleCache, tokens, true);
+		MessageSet results = analyze(fileName, m, config, moduleCache, tokens, code, true);
 		foreach (result; results[])
 		{
 			writeJSON(result.key, result.fileName, result.line, result.column, result.message);
@@ -167,7 +168,7 @@ bool analyze(string[] fileNames, const StaticAnalysisConfig config,
 		assert(m);
 		if (errorCount > 0 || (staticAnalyze && warningCount > 0))
 			hasErrors = true;
-		MessageSet results = analyze(fileName, m, config, moduleCache, tokens, staticAnalyze);
+		MessageSet results = analyze(fileName, m, config, moduleCache, tokens, code, staticAnalyze);
 		if (results is null)
 			continue;
 		foreach (result; results[])
@@ -197,7 +198,7 @@ const(Module) parseModule(string fileName, ubyte[] code, RollbackAllocator* p,
 }
 
 MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig analysisConfig,
-		ref ModuleCache moduleCache, const(Token)[] tokens, bool staticAnalyze = true)
+		ref ModuleCache moduleCache, const(Token)[] tokens, ubyte[] code, bool staticAnalyze = true)
 {
 	import dsymbol.symbol : DSymbol;
 
@@ -349,6 +350,10 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
     if (analysisConfig.lambda_return_check != Check.disabled)
 		checks ~= new LambdaReturnCheck(fileName,
         analysisConfig.lambda_return_check == Check.skipTests && !ut);
+
+    if (analysisConfig.allman_braces_check != Check.disabled)
+		checks ~= new AllManCheck(fileName, code,
+        analysisConfig.allman_braces_check == Check.skipTests && !ut);
 
 	version (none)
 		if (analysisConfig.redundant_if_check != Check.disabled)

--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -60,6 +60,7 @@ import analysis.alias_syntax_check;
 import analysis.static_if_else;
 import analysis.lambda_return_check;
 import analysis.allman;
+import analysis.trailing_whitespace;
 
 import dsymbol.string_interning : internString;
 import dsymbol.scope_;
@@ -354,6 +355,10 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
     if (analysisConfig.allman_braces_check != Check.disabled)
 		checks ~= new AllManCheck(fileName, code,
         analysisConfig.allman_braces_check == Check.skipTests && !ut);
+
+    if (analysisConfig.trailing_whitespace_check != Check.disabled)
+		checks ~= new TrailingWhitespaceCheck(fileName, code,
+        analysisConfig.trailing_whitespace_check == Check.skipTests && !ut);
 
 	version (none)
 		if (analysisConfig.redundant_if_check != Check.disabled)

--- a/src/analysis/trailing_whitespace.d
+++ b/src/analysis/trailing_whitespace.d
@@ -1,0 +1,91 @@
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module analysis.trailing_whitespace;
+
+import dparse.lexer;
+import dparse.ast;
+import analysis.base : BaseAnalyzer, Message;
+import dsymbol.scope_ : Scope;
+
+/**
+Checks whether a file contains trailing whitespace
+*/
+class TrailingWhitespaceCheck : BaseAnalyzer
+{
+    ubyte[] code;
+
+    ///
+	this(string fileName, ubyte[] code, bool skipTests = false)
+	{
+		super(fileName, null, skipTests);
+		this.code = code;
+    }
+
+	override void visit(const Module)
+    {
+        findTrailingWS();
+    }
+
+	alias visit = ASTVisitor.visit;
+
+private:
+
+    /**
+    Searches for trailing whitespace
+    */
+    void findTrailingWS()
+    {
+        import std.utf: byCodeUnit;
+        import std.ascii: isWhite;
+        import std.typecons: tuple;
+        auto text = (cast(char[]) code).byCodeUnit;
+        size_t line = 0;
+        size_t column = 0;
+        bool hasWhitespace;
+        foreach (s; text)
+        {
+            if (s == '\n')
+            {
+                if (hasWhitespace)
+                    addErrorMessage(line, column, KEY, MESSAGE);
+                line++;
+                column = 0;
+            }
+            else
+            {
+                if (isWhite(s))
+                    hasWhitespace = true;
+                else
+                    hasWhitespace = false;
+                column++;
+            }
+        }
+    }
+
+	enum string KEY = "dscanner.style.trailing_whitespace";
+	enum string MESSAGE = "Trailing whitespace detected";
+}
+
+unittest
+{
+	import analysis.config : StaticAnalysisConfig;
+    import analysis.helpers;
+    import std.stdio;
+
+	StaticAnalysisConfig sac;
+	sac.trailing_whitespace_check = "enabled";
+
+	auto msgs = getAnalyzerWarnings(q{
+        void testTrailing()
+        {
+            a = 1;  
+        }
+	}c, sac);
+    assert(msgs.length == 1);
+    Message msg = Message("test", 3, 20, "dscanner.style.trailing_whitespace", "Trailing whitespace detected");
+    assert(msgs.front == msg);
+
+	stderr.writeln("Unittest for TrailingWhitespaceCheck passed.");
+}


### PR DESCRIPTION
fixes #324 - this is based on #344 and #345 (as it needs raw code access and the modifications to the message warnings helper)