### PR TITLE
Added a mechanism for searching for dscanner.ini upwards through the file hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ To avoid these cases, it's possible to pass the "--skipTests" option.
 
 #### Configuration
 By default all checks are enabled. Individual checks can be enabled or disabled
-by using a configuration file. Running ```dscanner --defaultConfig``` will
-generate a default configuration file and print the file's location. The
-"--config" option will allow you to specify the path to a configuration file if
-you do not want to use the one created by the "--defaultConfig" option.
+by using a configuration file. Such a file can be placed, for example, is the root directory of your project.
+Running ```dscanner --defaultConfig``` will generate a default configuration file and print the file's location.
+You can also specify the path to a configuration file by using the "--config" option if
+you want to override the default or the local settings.
 
 For each check, three values are possible:
 * `"disabled"`: the check is not performed.
@@ -179,6 +179,7 @@ outline of the file's declarations to stdout.
 By default Dscanner uses the configuration file given in `$HOME/.config/dscanner/dscanner.ini`.
 Run `--defaultConfig` to regenerate it.
 The `--config` option allows one to use a custom configuration file.
+If a `dscanner.ini` file is locate in the working directory or any of it's parents, it overrides any other configuration files.
 
 ### AST Dump
 The "--ast" or "--xml" options will dump the complete abstract syntax tree of

--- a/src/main.d
+++ b/src/main.d
@@ -429,9 +429,9 @@ version (FreeBSD) version = useXDG;
 version (OSX) version = useXDG;
 
 /**
- * Locates the configuration file
+ * Locates the default configuration file
  */
-string getConfigurationLocation()
+string getDefaultConfigurationLocation()
 {
 	version (useXDG)
 	{
@@ -451,4 +451,41 @@ string getConfigurationLocation()
 	}
 	else version (Windows)
 		return CONFIG_FILE_NAME;
+}
+
+/**
+ * Searches upwards from the CWD through the directory hierarchy
+ */
+string tryFindConfigurationLocation()
+{
+	auto path = pathSplitter(getcwd());
+	string result;
+
+	while (!path.empty)
+	{
+		result = buildPath(buildPath(path), CONFIG_FILE_NAME);
+
+		if (exists(result))
+			break;
+
+		path.popBack();
+	}
+
+	if (path.empty)
+		return null;
+
+	return result;
+}
+
+/**
+ * Tries to find a config file and returns the default one on failure
+ */
+string getConfigurationLocation()
+{
+	immutable config = tryFindConfigurationLocation();
+
+	if (config !is null)
+		return config;
+
+	return getDefaultConfigurationLocation();
 }


### PR DESCRIPTION
This is the most trivial attempt at locating a custom config file I could think off. The issue #332 is related, however I did not make the search stop whenever a `.git` directory occurs, because I did not like the idea of dscanner ignoring my custom ~/.config/.../dscanner.ini file whenever I am editing code within a git repository without dscanner preferences.