### PR TITLE
add detection of undocumented enums and their members

### DIFF
--- a/src/analysis/undocumented.d
+++ b/src/analysis/undocumented.d
@@ -133,7 +133,9 @@ class UndocumentedDeclarationCheck : BaseAnalyzer
 	{
 	}
 
+	mixin V!AnonymousEnumMember;
 	mixin V!ClassDeclaration;
+	mixin V!EnumDeclaration;
 	mixin V!InterfaceDeclaration;
 	mixin V!StructDeclaration;
 	mixin V!UnionDeclaration;


### PR DESCRIPTION
Maybe there's a specific reason why they're were not added in first place ? I think that even if the member names are often explicit it cannot tells everything.