### PR TITLE
Proposal: Add an alternative highlighter

### DIFF
--- a/src/althighlighter.d
+++ b/src/althighlighter.d
@@ -1,0 +1,88 @@
+//          Copyright Brian Schott (Hackerpilot) 2012.
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module althighlighter;
+
+import std.stdio;
+import std.array;
+import std.conv;
+import std.string;
+import dparse.lexer;
+
+// http://ethanschoonover.com/solarized
+void highlight(R)(ref R tokens, string fileName)
+{
+	while (!tokens.empty)
+	{
+		auto t = tokens.front;
+		tokens.popFront();
+		if (isBasicType(t.type))
+		{
+			write("type");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(str(t.type).length));
+		}
+		else if (isKeyword(t.type))
+		{
+			write("keyword");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(str(t.type).length));
+		}
+		else if (t.type == tok!"comment")
+		{
+			write("com");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(t.text.length));
+		}
+		else if (isStringLiteral(t.type) || t.type == tok!"characterLiteral")
+		{
+			write("str");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(t.text.length));
+		}
+		else if (isNumberLiteral(t.type))
+		{
+			write("num");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(t.text.length));
+		}
+		else if (isOperator(t.type))
+		{
+			write("op");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(str(t.type).length));
+		}
+		else if (t.type == tok!"specialTokenSequence" || t.type == tok!"scriptLine")
+		{
+			write("special");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(t.text.length));
+		}
+		else
+		{
+			string text = t.text;
+			text = text.replace("<", "&lt;");
+
+			version(Windows)
+				text = text.replace("\r", "");
+
+			text = strip(text);
+
+			if (text.length == 0)
+				continue;
+
+			write("other");
+			writeln("," ~ to!string(t.index) ~ "," ~ to!string(t.text.length));
+		}
+			
+		
+
+		
+
+	}
+}
+
+void writeSpan(string cssClass, string value)
+{
+	version (Windows)
+		stdout.write(`<span class="`, cssClass, `">`, value.replace("&",
+				"&amp;").replace("<", "&lt;").replace("\r", ""), `</span>`);
+	else
+		stdout.write(`<span class="`, cssClass, `">`, value.replace("&",
+				"&amp;").replace("<", "&lt;"), `</span>`);
+}

--- a/src/main.d
+++ b/src/main.d
@@ -20,6 +20,7 @@ import dparse.parser;
 import dparse.rollback_allocator;
 
 import highlighter;
+import althighlighter;
 import stats;
 import ctags;
 import etags;
@@ -45,6 +46,7 @@ else
 {
 	bool sloc;
 	bool highlight;
+	bool althighlight;
 	bool ctags;
 	bool etags;
 	bool etagsAll;
@@ -73,6 +75,7 @@ else
 		getopt(args, std.getopt.config.caseSensitive,
 				"sloc|l", &sloc,
 				"highlight", &highlight,
+				"althighlight", &althighlight,
 				"ctags|c", &ctags,
 				"help|h", &help,
 				"etags|e", &etags,
@@ -149,7 +152,7 @@ else
 	if (absImportPaths.length)
 		moduleCache.addImportPaths(absImportPaths);
 
-	immutable optionCount = count!"a"([sloc, highlight, ctags, tokenCount, syntaxCheck, ast, imports,
+	immutable optionCount = count!"a"([sloc, highlight, althighlight, ctags, tokenCount, syntaxCheck, ast, imports,
 			outline, tokenDump, styleCheck, defaultConfig, report,
 			symbolName !is null, etags, etagsAll, recursiveImports]);
 	if (optionCount > 1)
@@ -178,7 +181,7 @@ else
 		writeln("Writing default config file to ", s);
 		writeINIFile(saConfig, s);
 	}
-	else if (tokenDump || highlight)
+	else if (tokenDump || highlight || althighlight)
 	{
 		ubyte[] bytes = usingStdin ? readStdin() : readFile(args[1]);
 		LexerConfig config;
@@ -188,6 +191,12 @@ else
 		{
 			auto tokens = byToken(bytes, config, &cache);
 			highlighter.highlight(tokens, args.length == 1 ? "stdin" : args[1]);
+			return 0;
+		}
+		else if (althighlight)
+		{
+			auto tokens = byToken(bytes, config, &cache);
+			althighlighter.highlight(tokens, args.length == 1 ? "stdin" : args[1]);
 			return 0;
 		}
 		else if (tokenDump)


### PR DESCRIPTION
The current highlighter outputs HTML styled code, I am working on D support for an IDE that doesn't use an HTML based text editor and would love to have an alternative highlighter that outputs something simpler. This is just a proposal to start a dialog and I am willing to refactor or rename anything in here.

The format I propose is as following:
*One token per line*
TYPE, Chars from start of file, Type/Text length

This format is extremely simple and powerful enough for us to highlight on, here's a printscreen of an example file and it's output: http://i.imgur.com/2GY74vl.png

In the future I would love if libdparse could detect that the second "other,26,3" was referring to the name "Foo" that I gave to my class.