### PR TITLE
Allow stdin everywhere (fix #317)

### DIFF
--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -117,7 +117,7 @@ void generateReport(string[] fileNames, const StaticAnalysisConfig config,
 	ulong lineOfCodeCount;
 	foreach (fileName; fileNames)
 	{
-		auto code = fileName == "stdin" ? readStdin() : readFile(fileName);
+		auto code = readFile(fileName);
 		// Skip files that could not be read and continue with the rest
 		if (code.length == 0)
 			continue;
@@ -155,7 +155,7 @@ bool analyze(string[] fileNames, const StaticAnalysisConfig config,
 	bool hasErrors = false;
 	foreach (fileName; fileNames)
 	{
-		auto code = fileName == "stdin" ? readStdin() : readFile(fileName);
+		auto code = readFile(fileName);
 		// Skip files that could not be read and continue with the rest
 		if (code.length == 0)
 			continue;

--- a/src/ctags.d
+++ b/src/ctags.d
@@ -33,7 +33,7 @@ void printCtags(File output, string[] fileNames)
 	foreach (fileName; fileNames)
 	{
 		RollbackAllocator rba;
-		File f = File(fileName);
+		File f = fileName == "stdin" ? std.stdio.stdin : File(fileName);
 		if (f.size == 0)
 			continue;
 		auto bytes = uninitializedArray!(ubyte[])(to!size_t(f.size));

--- a/src/etags.d
+++ b/src/etags.d
@@ -42,7 +42,7 @@ void printEtags(File output, bool tagAll, string[] fileNames)
 	foreach (fileName; fileNames)
 	{
 		RollbackAllocator rba;
-		File f = File(fileName);
+		File f = fileName == "stdin" ? std.stdio.stdin : File(fileName);
 		if (f.size == 0)
 			continue;
 		auto bytes = uninitializedArray!(ubyte[])(to!size_t(f.size));

--- a/src/readers.d
+++ b/src/readers.d
@@ -21,6 +21,8 @@ ubyte[] readStdin()
 
 ubyte[] readFile(string fileName)
 {
+	if (fileName == "stdin")
+		return readStdin();
 	if (!exists(fileName))
 	{
 		stderr.writefln("%s does not exist", fileName);
@@ -54,7 +56,7 @@ string[] expandArgs(string[] args)
 		args ~= ".";
 	foreach (arg; args[1 .. $])
 	{
-		if (isFileSafe(arg))
+		if (arg == "stdin" || isFileSafe(arg))
 			rVal ~= arg;
 		else
 			foreach (item; dirEntries(arg, SpanMode.breadth).map!(a => a.name))

--- a/src/symbol_finder.d
+++ b/src/symbol_finder.d
@@ -23,8 +23,8 @@ void findDeclarationOf(File output, string symbolName, string[] fileNames)
 	auto visitor = new FinderVisitor(output, symbolName);
 	foreach (fileName; fileNames)
 	{
-		File f = File(fileName);
-		assert(isFile(fileName));
+		File f = fileName == "stdin" ? std.stdio.stdin : File(fileName);
+		assert(fileName == "stdin" || isFile(fileName));
 		if (f.size == 0)
 			continue;
 		auto bytes = uninitializedArray!(ubyte[])(to!size_t(f.size));


### PR DESCRIPTION
readFile can now read from stdin and every function which used expandArgs has been checked and modified to work with stdin