### PR TITLE
Add check for explictly annotated unittests

### DIFF
--- a/src/analysis/config.d
+++ b/src/analysis/config.d
@@ -150,4 +150,7 @@ struct StaticAnalysisConfig
 
 	@INI("Check for sortedness of imports")
 	string imports_sortedness = Check.disabled;
+
+	@INI("Check for explicitly annotated unittests")
+	string explicitly_annotated_unittests = Check.disabled;
 }

--- a/src/analysis/explicitly_annotated_unittests.d
+++ b/src/analysis/explicitly_annotated_unittests.d
@@ -1,0 +1,116 @@
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+module analysis.explicitly_annotated_unittests;
+
+import dparse.lexer;
+import dparse.ast;
+import analysis.base : BaseAnalyzer;
+
+import std.stdio;
+
+/**
+ * Requires unittests to be explicitly annotated with either @safe or @system
+ */
+class ExplicitlyAnnotatedUnittestCheck : BaseAnalyzer
+{
+	enum string KEY = "dscanner.style.explicitly_annotated_unittest";
+	enum string MESSAGE = "A unittest should be annotated with at least @safe or @system";
+
+	///
+	this(string fileName, bool skipTests = false)
+	{
+		super(fileName, null, skipTests);
+	}
+
+	override void visit(const Declaration decl)
+	{
+		if (decl.unittest_ !is null)
+		{
+			bool isSafeOrSystem = false;
+			if (decl.attributes !is null)
+			foreach (attribute; decl.attributes)
+			{
+				if (attribute.atAttribute !is null)
+				{
+					auto token = attribute.atAttribute.identifier.text;
+					if (token == "safe" || token == "system")
+					{
+						isSafeOrSystem = true;
+						break;
+					}
+				}
+			}
+			if (!isSafeOrSystem)
+				addErrorMessage(decl.unittest_.line, decl.unittest_.column, KEY, MESSAGE);
+		}
+		decl.accept(this);
+	}
+
+	alias visit = BaseAnalyzer.visit;
+
+}
+
+unittest
+{
+	import std.stdio : stderr;
+	import std.format : format;
+	import analysis.config : StaticAnalysisConfig, Check;
+	import analysis.helpers : assertAnalyzerWarnings;
+
+	StaticAnalysisConfig sac;
+	sac.explicitly_annotated_unittests = Check.enabled;
+
+	assertAnalyzerWarnings(q{
+		@safe unittest {
+
+		}
+
+		@system unittest {
+
+		}
+
+		pure nothrow @system @nogc unittest {
+
+		}
+
+		unittest // [warn]: %s
+		{
+
+		}
+		pure nothrow @nogc unittest // [warn]: %s
+		{
+		}
+	}c.format(
+		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
+		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
+	), sac);
+
+	// nested
+	assertAnalyzerWarnings(q{
+		struct Foo
+		{
+			@safe unittest {
+
+			}
+
+			@system unittest {
+
+			}
+
+			unittest // [warn]: %s
+			{
+
+			}
+			pure nothrow @nogc unittest // [warn]: %s
+			{
+			}
+		}
+	}c.format(
+		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
+		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
+	), sac);
+
+	stderr.writeln("Unittest for ExplicitlyAnnotatedUnittestCheck passed.");
+}

--- a/src/analysis/explicitly_annotated_unittests.d
+++ b/src/analysis/explicitly_annotated_unittests.d
@@ -28,13 +28,13 @@ class ExplicitlyAnnotatedUnittestCheck : BaseAnalyzer
 	{
 		if (decl.unittest_ !is null)
 		{
-			bool isSafeOrSystem = false;
+			bool isSafeOrSystem;
 			if (decl.attributes !is null)
 			foreach (attribute; decl.attributes)
 			{
 				if (attribute.atAttribute !is null)
 				{
-					auto token = attribute.atAttribute.identifier.text;
+					const token = attribute.atAttribute.identifier.text;
 					if (token == "safe" || token == "system")
 					{
 						isSafeOrSystem = true;
@@ -63,25 +63,12 @@ unittest
 	sac.explicitly_annotated_unittests = Check.enabled;
 
 	assertAnalyzerWarnings(q{
-		@safe unittest {
+		@safe unittest {}
+		@system unittest {}
+		pure nothrow @system @nogc unittest {}
 
-		}
-
-		@system unittest {
-
-		}
-
-		pure nothrow @system @nogc unittest {
-
-		}
-
-		unittest // [warn]: %s
-		{
-
-		}
-		pure nothrow @nogc unittest // [warn]: %s
-		{
-		}
+		unittest {} // [warn]: %s
+		pure nothrow @nogc unittest {} // [warn]: %s
 	}c.format(
 		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
 		ExplicitlyAnnotatedUnittestCheck.MESSAGE,
@@ -91,21 +78,11 @@ unittest
 	assertAnalyzerWarnings(q{
 		struct Foo
 		{
-			@safe unittest {
+			@safe unittest {}
+			@system unittest {}
 
-			}
-
-			@system unittest {
-
-			}
-
-			unittest // [warn]: %s
-			{
-
-			}
-			pure nothrow @nogc unittest // [warn]: %s
-			{
-			}
+			unittest {} // [warn]: %s
+			pure nothrow @nogc unittest {} // [warn]: %s
 		}
 	}c.format(
 		ExplicitlyAnnotatedUnittestCheck.MESSAGE,

--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -61,6 +61,7 @@ import analysis.static_if_else;
 import analysis.lambda_return_check;
 import analysis.auto_function;
 import analysis.imports_sortedness;
+import analysis.explicitly_annotated_unittests;
 
 import dsymbol.string_interning : internString;
 import dsymbol.scope_;
@@ -363,6 +364,10 @@ MessageSet analyze(string fileName, const Module m, const StaticAnalysisConfig a
 	if (analysisConfig.imports_sortedness != Check.disabled)
 		checks ~= new ImportSortednessCheck(fileName,
 		analysisConfig.imports_sortedness == Check.skipTests && !ut);
+
+	if (analysisConfig.explicitly_annotated_unittests != Check.disabled)
+		checks ~= new ExplicitlyAnnotatedUnittestCheck(fileName,
+		analysisConfig.explicitly_annotated_unittests == Check.skipTests && !ut);
 
 	version (none)
 		if (analysisConfig.redundant_if_check != Check.disabled)


### PR DESCRIPTION
Coming from https://github.com/dlang/phobos/pull/4952, this adds a style checker for explicitly annotated unittests.
For example these two example are properly annotated:

```d
@safe unittest {

}

@system unittest {

}
```

While for these two it will give a nice error message:

```d
unittest // [warn]: A unittest should be annotated with at least @safe or @system
{

}
pure nothrow @nogc unittest // [warn]: A unittest should be annotated with at least @safe or @system
{
}
```