### PR TITLE
Escape backslashes before quotes in JSON report

### DIFF
--- a/src/analysis/run.d
+++ b/src/analysis/run.d
@@ -97,10 +97,10 @@ void writeJSON(string key, string fileName, size_t line, size_t column, string m
 		first = false;
 	writeln("    {");
 	writeln(`      "key": "`, key, `",`);
-	writeln(`      "fileName": "`, fileName.replace(`"`, `\"`).replace("\\", "\\\\"), `",`);
+	writeln(`      "fileName": "`, fileName.replace("\\", "\\\\").replace(`"`, `\"`), `",`);
 	writeln(`      "line": `, line, `,`);
 	writeln(`      "column": `, column, `,`);
-	writeln(`      "message": "`, message.replace(`"`, `\"`).replace("\\", "\\\\"), `"`);
+	writeln(`      "message": "`, message.replace("\\", "\\\\").replace(`"`, `\"`), `"`);
 	write("    }");
 }
 


### PR DESCRIPTION
When escaping backslashes and quotes to write the JSON report, quotes are the first to be escaped. But then the backslash used to escape them is also escaped and the quote ends up not being escaped.