### PR TITLE
Add libddoc to the dmd commandline in build.bat

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -22,7 +22,8 @@ for %%x in (dsymbol\src\dsymbol\builtin\*.d) do set DSYMBOL=!DSYMBOL! %%x
 for %%x in (dsymbol\src\dsymbol\conversion\*.d) do set DSYMBOL=!DSYMBOL! %%x
 for %%x in (containers\src\containers\*.d) do set CONTAINERS=!CONTAINERS! %%x
 for %%x in (containers\src\containers\internal\*.d) do set CONTAINERS=!CONTAINERS! %%x
+for %%x in (libddoc\src\ddoc\*.d) do set DDOC=!DDOC! %%x
 
 @echo on
-dmd %CORE% %STD% %LIBDPARSE% %ANALYSIS% %INIFILED% %DSYMBOL% %CONTAINERS% %DFLAGS% -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -ofdscanner.exe
+dmd %CORE% %STD% %LIBDPARSE% %ANALYSIS% %INIFILED% %DSYMBOL% %CONTAINERS% %DFLAGS% %DDOC% -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -ofdscanner.exe
 


### PR DESCRIPTION
This script is used by the automated compilation in vscode.
The breaking change was - https://github.com/Hackerpilot/Dscanner/commit/f16b1e854a411c670c182afdd3d76adff9210a09
When adding new dependencies we need to also report them here.