### PR TITLE
build.bat is out of date

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -9,6 +9,7 @@ set ANALYSIS=
 set INIFILED=
 set DSYMBOL=
 set CONTAINERS=
+set LIBDDOC=
 
 for %%x in (src\*.d) do set CORE=!CORE! %%x
 for %%x in (src\analysis\*.d) do set ANALYSIS=!ANALYSIS! %%x
@@ -16,6 +17,7 @@ for %%x in (libdparse\experimental_allocator\src\std\experimental\allocator\*.d)
 for %%x in (libdparse\experimental_allocator\src\std\experimental\allocator\building_blocks\*.d) do set STD=!STD! %%x
 for %%x in (libdparse\src\dparse\*.d) do set LIBDPARSE=!LIBDPARSE! %%x
 for %%x in (libdparse\src\std\experimental\*.d) do set LIBDPARSE=!LIBDPARSE! %%x
+for %%x in (libddoc\src\ddoc\*.d) do set LIBDDOC=!LIBDDOC! %%x
 for %%x in (inifiled\source\*.d) do set INIFILED=!INIFILED! %%x
 for %%x in (dsymbol\src\dsymbol\*.d) do set DSYMBOL=!DSYMBOL! %%x
 for %%x in (dsymbol\src\dsymbol\builtin\*.d) do set DSYMBOL=!DSYMBOL! %%x
@@ -24,5 +26,5 @@ for %%x in (containers\src\containers\*.d) do set CONTAINERS=!CONTAINERS! %%x
 for %%x in (containers\src\containers\internal\*.d) do set CONTAINERS=!CONTAINERS! %%x
 
 @echo on
-dmd %CORE% %STD% %LIBDPARSE% %ANALYSIS% %INIFILED% %DSYMBOL% %CONTAINERS% %DFLAGS% -I"libdparse\src" -I"dsymbol\src" -I"containers\src" -ofdscanner.exe
+dmd %CORE% %STD% %LIBDPARSE% %LIBDDOC% %ANALYSIS% %INIFILED% %DSYMBOL% %CONTAINERS% %DFLAGS% -I"libdparse\src" -I"dsymbol\src" -I"containers\src"  -I"libddoc\src" -ofdscanner.exe
 


### PR DESCRIPTION
Test command: cmd.exe /c build.bat
(workspace-d uses this command)

Error message:
```
src\analysis\properly_documented_public_functions.d(163): Error: module comments is in file 'ddoc\comments.d' which cannot be read
import path[0] = libdparse\src
import path[1] = dsymbol\src
import path[2] = containers\src
import path[3] = d:\DMD\dmd2\windows\bin\..\..\src\phobos
import path[4] = d:\DMD\dmd2\windows\bin\..\..\src\druntime\import
Failed to install Dscanner (Error code 1)
```